### PR TITLE
Allow A0 to be set in the inputs file

### DIFF
--- a/code/exec2D/driver.cpp
+++ b/code/exec2D/driver.cpp
@@ -162,8 +162,8 @@ int main(int argc, char* argv[]) {
       }
     else if (rateFactorType == "patersonRate")
       {
-	PatersonRateFactor rateFactor(seconds_per_unit_time);
-	ParmParse arPP("PatersonRate");
+	ParmParse arPP("patersonRate");
+	PatersonRateFactor rateFactor(seconds_per_unit_time,arPP);
 	amrObject.setRateFactor(&rateFactor);
       }
     else if (rateFactorType == "zwingerRate")
@@ -187,7 +187,8 @@ int main(int argc, char* argv[]) {
     
     if (basalRateFactorType == "patersonRate")
       {
-	PatersonRateFactor rateFactor(seconds_per_unit_time);
+	ParmParse arPP("basalPatersonRate");
+	PatersonRateFactor rateFactor(seconds_per_unit_time,arPP);
 	rateFactor.setA0(1.0);
 	amrObject.setBasalRateFactor(&rateFactor);
       }

--- a/code/src/ConstitutiveRelation.H
+++ b/code/src/ConstitutiveRelation.H
@@ -16,6 +16,7 @@
 #include "FluxBox.H"
 #include "LevelSigmaCS.H"
 #include "CellToEdge.H"
+#include "ParmParse.H"
 #include "NamespaceHeader.H"
 
 
@@ -301,7 +302,7 @@ class PatersonRateFactor : public RateFactor
 
 public:
 
-  PatersonRateFactor(Real a_seconds_per_unit_time);
+  PatersonRateFactor(Real a_seconds_per_unit_time, ParmParse& a_pp);
  
   void setDefaultParameters(Real a_seconds_per_unit_time);
  

--- a/code/src/ConstitutiveRelation.cpp
+++ b/code/src/ConstitutiveRelation.cpp
@@ -765,9 +765,13 @@ RateFactor* ArrheniusRateFactor::getNewRateFactor() const
   
 }
 
-PatersonRateFactor::PatersonRateFactor(Real a_seconds_per_unit_time)
+PatersonRateFactor::PatersonRateFactor(Real a_seconds_per_unit_time, ParmParse& a_pp)
 {
   setDefaultParameters(a_seconds_per_unit_time);
+  a_pp.query("A0",m_A0);
+  Real A0_multiplier = 1.0;
+  a_pp.query("A0_multiplier",A0_multiplier);
+  m_A0 *= A0_multiplier;
 }
 
 void PatersonRateFactor::setDefaultParameters(Real a_seconds_per_unit_time)

--- a/code/src/cwrapper.cpp
+++ b/code/src/cwrapper.cpp
@@ -422,8 +422,8 @@ void init_bisicles_instance(BisiclesWrapper& a_wrapper)
     }
   else if (rateFactorType == "patersonRate")
     {
-      PatersonRateFactor rateFactor(seconds_per_unit_time);
-      ParmParse arPP("PatersonRate");
+      ParmParse arPP("patersonRate");
+      PatersonRateFactor rateFactor(seconds_per_unit_time,arPP);
       amrObject.setRateFactor(&rateFactor);
     }
   else if (rateFactorType == "zwingerRate")
@@ -447,7 +447,8 @@ void init_bisicles_instance(BisiclesWrapper& a_wrapper)
   
   if (basalRateFactorType == "patersonRate")
     {
-      PatersonRateFactor rateFactor(seconds_per_unit_time);
+	  ParmParse arPP("basalPatersonRate");
+      PatersonRateFactor rateFactor(seconds_per_unit_time,arPP);
       rateFactor.setA0(1.0);
       amrObject.setBasalRateFactor(&rateFactor);
     }


### PR DESCRIPTION
Allow A0 to be set in the inputs file for patersonRate with patersonRate.A0 or patersonRate.A0_multiplier.